### PR TITLE
feat(component): add Certificate Rotator

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Following is a list of Greengrass components.
 * [Node-RED Docker](https://github.com/awslabs/aws-greengrass-labs-nodered-docker): This component installs Node-RED on the Greengrass core device using the official Node-RED docker container. This component depends on the [Node-RED Auth](https://github.com/awslabs/aws-greengrass-labs-nodered-auth) component which must be explicitly deployed and configured. To deploy Node-RED flows to AWS Greengrass devices running Node-RED you can take advantage of [Node-RED CLI for Greengrass](https://github.com/awslabs/aws-greengrass-labs-node-red-app-cli)
 * [Node-RED Auth](https://github.com/awslabs/aws-greengrass-labs-nodered-auth): This component configure a user name and password to secure the Node-RED instance running 
 * [OpenThread Border Router](https://github.com/awslabs/aws-greengrass-labs-openthread-border-router): This component deploys the [OpenThread Border Router](https://openthread.io/guides/border-router) Docker container, helping users to compose a Matter device that includes a Thread border router.
+* [Certificate Rotator](https://github.com/awslabs/aws-greengrass-labs-certificate-rotator): This component and companion cloud backend provides a means of rotating the AWS IoT Greengrass core device certificate and private key, across your fleet, at scale.
 
 ### AWS provided components
 

--- a/cli-components/community-components.json
+++ b/cli-components/community-components.json
@@ -13,5 +13,6 @@
     "aws-greengrass-labs-nodered": "https://github.com/awslabs/aws-greengrass-labs-nodered/archive/refs/heads/main.zip",
     "aws-greengrass-labs-nodered-auth": "https://github.com/awslabs/aws-greengrass-labs-nodered-auth/archive/refs/heads/main.zip",
     "aws-greengrass-labs-database-postgresql": "https://github.com/awslabs/aws-greengrass-labs-database-postgresql/releases/download/v1.0.0/aws-greengrass-labs-database-postgresql.zip",
-    "aws-greengrass-labs-openthread-border-router": "https://github.com/awslabs/aws-greengrass-labs-openthread-border-router/archive/refs/heads/main.zip"
+    "aws-greengrass-labs-openthread-border-router": "https://github.com/awslabs/aws-greengrass-labs-openthread-border-router/archive/refs/heads/main.zip",
+    "aws-greengrass-labs-certificate-rotator": "https://github.com/awslabs/aws-greengrass-labs-certificate-rotator/archive/refs/heads/main.zip"
 }


### PR DESCRIPTION
Use this PR to list your component in the [aws-greengrass-software-catalog](https://github.com/aws-greengrass/aws-greengrass-software-catalog) repository. Update [README](https://github.com/aws-greengrass/aws-greengrass-software-catalog/blob/main/README.md) file with your component details and provide other information as requested below.

## PR checklist
- [x ] Review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [ x] Check your code additions and commit messages don't fail the automated CI validation.
- [ x] Fill in the requested information in all the following sections.

## Description
Greengrass component and companion cloud backend for rotating the core device certificate and private key.

## Link to the component repository
https://github.com/awslabs/aws-greengrass-labs-certificate-rotator

## Motivation and context
Device certificate rotation is a best practice we recommend, but is undifferentiated heavy lifting. This component eases the development burden and helps customers to improve their security posture.

## QA Detail - Instructions to verify component functionality
See https://github.com/awslabs/aws-greengrass-labs-certificate-rotator

The component includes extensive unit and integrations tests, static analysis and security scanning.

## Acceptance criteria
Make sure your component home contains:
- [x ] Requirements - AWS and non-AWS resources required on device and in customer's AWS account.
- [x ] Instructions for installation of component, preferably "one-click or one-line".
- [ x] Instructions around what settings can be configured along with examples of workable defaults.
- [ x] Threat Modeling - List any potential security vulnerabilities for this component and how you've attempted to mitigate risks.
- [x ] Troubleshooting guide to help resolve customer issues. 
- [ x] Instructions about how customers can report issues related to component and get them addressed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
